### PR TITLE
fix: improve user search query handling with role filtering

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -12,6 +12,7 @@ import {
   Query,
   UseGuards,
   UseInterceptors,
+  Req
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
@@ -42,7 +43,17 @@ export class UserController {
 
   @Get()
   @Roles(Role.Admin)
-  async findAll(@Query() userQuery: UserQuery): Promise<User[]> {
+  async findAll(@Req() req: any): Promise<User[]> {
+    const userQuery: UserQuery = {};
+    
+    if (req.query.role && req.query.role !== 'all') {
+      userQuery.role = req.query.role;
+    }
+    
+    if (req.query.firstName) userQuery.firstName = req.query.firstName;
+    if (req.query.lastName) userQuery.lastName = req.query.lastName;
+    if (req.query.username) userQuery.username = req.query.username;
+    
     return await this.userService.findAll(userQuery);
   }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -23,19 +23,28 @@ export class UserService {
     return User.create(createUserDto).save();
   }
 
-async findAll(userQuery: UserQuery): Promise<User[]> {
-  Object.keys(userQuery).forEach((key) => {
-    userQuery[key] = ILike(`%${userQuery[key]}%`);
-  });
+  async findAll(userQuery: UserQuery): Promise<User[]> {
+    const whereClause: any = {};
+    
+    if (userQuery.role && userQuery.role !== 'all') {
+      whereClause.role = userQuery.role;
+    }
+    
+    Object.keys(userQuery).forEach((key) => {
+      if (key !== 'role' && userQuery[key] && userQuery[key].trim()) {
+        whereClause[key] = ILike(`%${userQuery[key]}%`);
+      }
+    });
 
-  return await User.find({
-    where: userQuery,
-    order: {
-      firstName: 'ASC',
-      lastName: 'ASC',
-    },
-  }) as User[];
-}
+    return await User.find({
+      where: Object.keys(whereClause).length > 0 ? whereClause : {},
+      order: {
+        firstName: 'ASC',
+        lastName: 'ASC',
+      },
+    }) as User[];
+  }
+  
   async findById(id: string): Promise<User> {
     const user = await User.findOne(id);
 


### PR DESCRIPTION
## Summary

Fix user search functionality that was experiencing data loading issues due to improper query parameter handling. Add role-based filtering with support for searching across all roles.

## Changes

- Fixed undefined/empty parameter handling in UserService.findAll() method
- Added separate logic for role filtering using exact match vs other fields using partial match with ILike
- Updated UserController.findAll() to properly construct UserQuery object
- Added support for role parameter with "all" option to search users with any role

## Why

The user search had the same issues as the course module where undefined/empty query parameters were causing data loading problems. The original code was applying ILike operations to undefined values and not properly filtering role-based searches. This fix prevents malformed query conditions and enables proper role filtering functionality.

## Tests

- Search without parameters returns all users
- Search by specific role returns only users with that role
- Search with role=all returns users with any role
- Combined filters work correctly (e.g., ?role=Admin&firstName=John)
- Empty/undefined parameters don't cause query issues